### PR TITLE
fix(release): disable parallel tests to stabilize TUI pilot suite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
       contents: write
     with:
       create-github-release: false
+      # supsrc's TUI pilot tests use shared Mock state that breaks under pytest-xdist.
+      # Disable parallel test execution for release runs until the tests are isolated.
+      parallel-tests: false
     secrets: inherit
 
   # TestPyPI publish runs in the caller so PyPI Trusted Publishing matches the


### PR DESCRIPTION
Follow-up to #2. test_tui_pilot.py's 3 tests (test_help_action, test_clear_log_action, test_hide_detail_pane) use shared Mock state that fails under pytest-xdist. Pass `parallel-tests: false` to the ci-tooling reusable for release runs only — unblocks v0.4.0 backfill signed-artifact upload.