### PR TITLE
test(tui): xfail test_repository_table_updates on darwin_amd64/CI

### DIFF
--- a/tests/unit/test_tui_pilot.py
+++ b/tests/unit/test_tui_pilot.py
@@ -140,6 +140,10 @@ class TestTuiPilotStateUpdates:
     """Test state updates and data display using Pilot."""
 
     @pytest.mark.asyncio
+    @pytest.mark.xfail(
+        FLAKY_PILOT,
+        reason="Textual pilot timing issue (macOS Intel + CI Linux) - StateUpdate post_message not observed reliably",
+    )
     async def test_repository_table_updates(
         self,
         mock_config_path: Path,


### PR DESCRIPTION
Same Textual-pilot timing flakiness pattern as the 3 already-xfailed tests (#4). StateUpdate posted via post_message isn't observed in the DataTable within pilot.pause() on macOS Intel CI runners (asserts 2 rows, sees 0). Brings the FLAKY_PILOT exemption count to 4.