### PR TITLE
chore(release): restore publish-testpypi + verify-testpypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,60 @@ jobs:
       parallel-tests: false
     secrets: inherit
 
-  # PyPI publish via trusted publisher bound to this repo's release.yml + env `pypi`.
-  # TestPyPI publish+verify intentionally omitted — supsrc does not have a TestPyPI
-  # trusted publisher configured, and since 0.4.0 already exists on PyPI, TestPyPI
-  # dry-run adds no value for this backfill. Restore publish-testpypi + verify-testpypi
-  # once test.pypi.org/manage/account/publishing has a publisher for
-  # provide-io/supsrc + release.yml + environment `testpypi`.
-  publish-pypi:
+  # TestPyPI publish runs in the caller so PyPI Trusted Publishing matches the
+  # OIDC job_workflow_ref against this repo's release.yml (reusable workflows
+  # are not matched by PyPI's publisher config).
+  publish-testpypi:
     needs: release
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/supsrc
+    steps:
+      - name: 📦 Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: release-artifacts
+          path: dist
+      - name: 📤 Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  # Install from TestPyPI and assert the installed version matches the release tag.
+  # Uses the helper scripts from ci-tooling/scripts/release/.
+  verify-testpypi:
+    needs: publish-testpypi
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 📥 Checkout ci-tooling helpers
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: provide-io/ci-tooling
+          ref: v0.4.2
+          path: .ci-tooling
+      - name: 🐍 Setup Python
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          python-version: "3.11"
+          enable-cache: false
+      - name: 🔖 Resolve version
+        id: ver
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: .ci-tooling/scripts/release/resolve-tag-version.sh >> "$GITHUB_OUTPUT"
+      - name: ✅ Install from TestPyPI and verify
+        run: |
+          .ci-tooling/scripts/release/verify-testpypi.sh supsrc "${{ steps.ver.outputs.version }}" "import supsrc; v = supsrc.__version__"
+
+  # PyPI publish via trusted publisher bound to this repo's release.yml + env `pypi`.
+  publish-pypi:
+    needs: verify-testpypi
     runs-on: ubuntu-24.04
     permissions:
       id-token: write


### PR DESCRIPTION
Reverts #5 now that the TestPyPI trusted publisher is configured for `provide-io/supsrc` + `release.yml` + env `testpypi`. Restores the standard caller shape matching the other 11 Python repos.